### PR TITLE
Feature/sprockets upgrade

### DIFF
--- a/Gemfile.rails_version
+++ b/Gemfile.rails_version
@@ -2,28 +2,36 @@
 # separate fragment so that it can be sourced from the test
 # application's Gemfile in addition to the main development Gemfile.
 
-env_rails_version = ENV["RAILS_VERSION"] || "default"
+env_rails_version = ENV["RAILS_VERSION"] || '4.2.10'
+
+gem "rails", "~> #{env_rails_version}"
 
 case env_rails_version
 when "master"
   {github: "rails/rails"}
-when "default"
-  gem "rails", "~> 4.2.5.0"
+when /^4.2.10/
+  gem 'bootstrap-sass', '~> 3.3.7'
+  gem 'jquery-rails'
+  gem 'simple_form', '~> 3.5.0'
+  gem "sprockets-rails", "~> 3.2.1"
+
+  # A JS runtime is required for Rails 4.0+
+  gem 'therubyracer', platforms: :ruby
+when /^4.2.5/, /^4.1/, /^4.0/
+  gem "sprockets-rails", "2.3.3"
+  gem 'simple_form', '~> 3.1.0'
+  gem 'bootstrap-sass', '3.3.1.0'
+
   # A JS runtime is required for Rails 4.0+
   gem 'therubyracer', platforms: :ruby
 when /^3.2/
-  gem "rails", "~> #{env_rails_version}"
+  gem 'strong_parameters'
   # A JS runtime is required for Rails 3.1+
   gem 'therubyracer', '~> 0.12.1'
-  gem 'strong_parameters'
-when /^4.0/
-  gem "rails", "~> #{env_rails_version}"
-  # A JS runtime is required for Rails 4.0+
-  gem 'therubyracer', platforms: :ruby
+
+  gem 'bootstrap-sass', '3.3.1.0'
+  gem 'simple_form', '~> 3.1.0'
+  gem "sprockets-rails", "2.3.3"
 else
   fail "Unsupported Rails version #{ENV['RAILS_VERSION']}"
 end
-
-gem "sprockets-rails", "2.3.3"
-gem 'simple_form', '~> 3.1.0'
-gem 'bootstrap-sass', '3.3.1.0'

--- a/Gemfile.rails_version
+++ b/Gemfile.rails_version
@@ -10,17 +10,17 @@ case env_rails_version
 when "master"
   {github: "rails/rails"}
 when /^4.2.10/
-  gem 'bootstrap-sass', '~> 3.3.6'
+  gem 'bootstrap-sass', '~> 3.3'
   gem 'jquery-rails'
-  gem 'simple_form', '~> 3.5.0'
-  gem "sprockets-rails", "~> 3.2.1"
+  gem 'simple_form', '~> 3.5'
+  gem "sprockets-rails", "~> 3.2"
 
   # A JS runtime is required for Rails 4.0+
   gem 'therubyracer', platforms: :ruby
 when /^4.2.5/, /^4.1/, /^4.0/
-  gem "sprockets-rails", "2.3.3"
-  gem 'simple_form', '~> 3.1.0'
-  gem 'bootstrap-sass', '3.3.1.0'
+  gem "sprockets-rails", "~> 2.3"
+  gem 'simple_form', '~> 3.1'
+  gem 'bootstrap-sass', '~> 3.3.1'
 
   # A JS runtime is required for Rails 4.0+
   gem 'therubyracer', platforms: :ruby
@@ -29,9 +29,9 @@ when /^3.2/
   # A JS runtime is required for Rails 3.1+
   gem 'therubyracer', '~> 0.12.1'
 
-  gem 'bootstrap-sass', '3.3.1.0'
+  gem 'bootstrap-sass', '~> 3.3.1'
   gem 'simple_form', '~> 3.1.0'
-  gem "sprockets-rails", "2.3.3"
+  gem "sprockets-rails", "~> 2.3.3"
 else
   fail "Unsupported Rails version #{ENV['RAILS_VERSION']}"
 end

--- a/Gemfile.rails_version
+++ b/Gemfile.rails_version
@@ -10,7 +10,7 @@ case env_rails_version
 when "master"
   {github: "rails/rails"}
 when /^4.2.10/
-  gem 'bootstrap-sass', '~> 3.3.7'
+  gem 'bootstrap-sass', '~> 3.3.6'
   gem 'jquery-rails'
   gem 'simple_form', '~> 3.5.0'
   gem "sprockets-rails", "~> 3.2.1"

--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ namespace :testbed do
     Tempfile.open('surveyor_Rakefile') do |f|
       f.write("application \"config.time_zone='Rome'\"\n")
       f.flush
-      sh "bundle exec rails new testbed --skip-bundle -m #{f.path}" # don't run bundle install until the Gemfile modifications
+      sh "bundle exec rails new testbed --skip-turbolinks --skip-bundle -m #{f.path}" # don't run bundle install until the Gemfile modifications
     end
     chdir('testbed') do
       gem_file_contents = File.read('Gemfile')

--- a/lib/generators/surveyor/templates/app/assets/javascripts/surveyor_all.js
+++ b/lib/generators/surveyor/templates/app/assets/javascripts/surveyor_all.js
@@ -1,4 +1,5 @@
-//= require surveyor/jquery-1.9.0
+//= require jquery
+//= require jquery_ujs
 //= require bootstrap
 //= require surveyor/jquery-ui-1.10.0.custom
 //= require surveyor/jquery-ui-timepicker-addon

--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -19,13 +19,11 @@ Gem::Specification.new do |s|
 
   s.add_dependency('rails', '>= 4.2')
   s.add_dependency('haml', '~> 4.0')
+  s.add_dependency('jquery-rails', '~> 4.3.1')
   s.add_dependency('sass-rails', '~> 5.0.0')
-  s.add_dependency('bootstrap-sass', '3.3.1.0')
-  s.add_dependency('simple_form', '~> 3.1.0')
   s.add_dependency('uuidtools', '~> 2.1')
   s.add_dependency('mustache', '~> 0.99')
   s.add_dependency('rabl', '~> 0.6')
-  s.add_dependency('sprockets', '2.11.0')
 
   s.add_development_dependency('yard')
   s.add_development_dependency('rake', '~> 11.0')
@@ -34,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec-rails', '~> 2.14.2')
   s.add_development_dependency('capybara', '~> 2.2.1')
   s.add_development_dependency('launchy', '~> 2.4.2')
-  s.add_development_dependency('poltergeist', '~>1.6.0')
+  s.add_development_dependency('poltergeist', '~>1.17.0')
   s.add_development_dependency('json_spec', '~> 1.1.1')
   s.add_development_dependency('factory_bot', '~> 4.8.0')
   s.add_development_dependency('database_cleaner', '~> 1.2.0')


### PR DESCRIPTION
Upgrade dependencies to work with newer (but still old) Sprockets lib and Rails 4.2.10.

When we move on to Rails 5, we will likely gut all of the UI components and make this a pure lib