### PR TITLE
RS-4292 Updates to allow specs to run in 5.1

### DIFF
--- a/lib/generators/surveyor/templates/db/migrate/add_api_id_to_question_groups.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_id_to_question_groups.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIdToQuestionGroups < ActiveRecord::Migration
+class AddApiIdToQuestionGroups < ActiveRecord::Migration[4.2]
   def self.up
     add_column :question_groups, :api_id, :string
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_api_ids.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_ids.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIds < ActiveRecord::Migration
+class AddApiIds < ActiveRecord::Migration[4.2]
   def self.up
     add_column :surveys, :api_id, :string
     add_column :questions, :api_id, :string

--- a/lib/generators/surveyor/templates/db/migrate/add_api_ids_to_response_sets_and_responses.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_api_ids_to_response_sets_and_responses.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddApiIdsToResponseSetsAndResponses < ActiveRecord::Migration
+class AddApiIdsToResponseSetsAndResponses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :response_sets, :api_id, :string
     add_column :responses, :api_id, :string

--- a/lib/generators/surveyor/templates/db/migrate/add_correct_answer_id_to_questions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_correct_answer_id_to_questions.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddCorrectAnswerIdToQuestions < ActiveRecord::Migration
+class AddCorrectAnswerIdToQuestions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :questions, :correct_answer_id, :integer
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_current_section_id_to_response_sets.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_current_section_id_to_response_sets.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddCurrentSectionIdToResponseSets < ActiveRecord::Migration
+class AddCurrentSectionIdToResponseSets < ActiveRecord::Migration[4.2]
   def self.up
     add_column :response_sets, :current_section_id, :integer
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_default_value_to_answers.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_default_value_to_answers.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddDefaultValueToAnswers < ActiveRecord::Migration
+class AddDefaultValueToAnswers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :answers, :default_value, :string
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_display_order_to_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_display_order_to_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddDisplayOrderToSurveys < ActiveRecord::Migration
+class AddDisplayOrderToSurveys < ActiveRecord::Migration[4.2]
   def self.up
     add_column :surveys, :display_order, :integer
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_display_type_to_answers.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_display_type_to_answers.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddDisplayTypeToAnswers < ActiveRecord::Migration
+class AddDisplayTypeToAnswers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :answers, :display_type, :string
     Answer.all.each{|a| a.update_attributes(:display_type => "hidden_label") if a.hide_label == true}

--- a/lib/generators/surveyor/templates/db/migrate/add_index_to_response_sets.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_index_to_response_sets.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddIndexToResponseSets < ActiveRecord::Migration
+class AddIndexToResponseSets < ActiveRecord::Migration[4.2]
   def self.up
     add_index(:response_sets, :access_code, :name => 'response_sets_ac_idx')
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_index_to_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_index_to_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddIndexToSurveys < ActiveRecord::Migration
+class AddIndexToSurveys < ActiveRecord::Migration[4.2]
   def self.up
     add_index(:surveys, :access_code, :name => 'surveys_ac_idx')
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_input_mask_attributes_to_answer.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_input_mask_attributes_to_answer.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddInputMaskAttributesToAnswer < ActiveRecord::Migration
+class AddInputMaskAttributesToAnswer < ActiveRecord::Migration[4.2]
   def self.up
     add_column :answers, :input_mask, :string
     add_column :answers, :input_mask_placeholder, :string

--- a/lib/generators/surveyor/templates/db/migrate/add_qualify_logic_to_answers.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_qualify_logic_to_answers.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddQualifyLogicToAnswers < ActiveRecord::Migration
+class AddQualifyLogicToAnswers < ActiveRecord::Migration[4.2]
   def self.up
     add_column :answers, :qualify_logic, :string
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_section_id_to_responses.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_section_id_to_responses.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddSectionIdToResponses < ActiveRecord::Migration
+class AddSectionIdToResponses < ActiveRecord::Migration[4.2]
   def self.up
     add_column :responses, :survey_section_id, :integer
     add_index :responses, :survey_section_id

--- a/lib/generators/surveyor/templates/db/migrate/add_unique_index_on_access_code_and_version_in_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_unique_index_on_access_code_and_version_in_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddUniqueIndexOnAccessCodeAndVersionInSurveys < ActiveRecord::Migration
+class AddUniqueIndexOnAccessCodeAndVersionInSurveys < ActiveRecord::Migration[4.2]
   def self.up
     add_index(:surveys, [ :access_code, :survey_version], :name => 'surveys_access_code_version_idx', :unique => true)
   end

--- a/lib/generators/surveyor/templates/db/migrate/add_unique_indicies.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_unique_indicies.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddUniqueIndicies < ActiveRecord::Migration
+class AddUniqueIndicies < ActiveRecord::Migration[4.2]
   def self.up
     remove_index(:response_sets, :name => 'response_sets_ac_idx')
     add_index(:response_sets, :access_code, :name => 'response_sets_ac_idx', :unique => true)

--- a/lib/generators/surveyor/templates/db/migrate/add_version_to_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_version_to_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class AddVersionToSurveys < ActiveRecord::Migration
+class AddVersionToSurveys < ActiveRecord::Migration[4.2]
   def self.up
     add_column :surveys, :survey_version, :integer, :default => 0
   end

--- a/lib/generators/surveyor/templates/db/migrate/api_ids_must_be_unique.rb
+++ b/lib/generators/surveyor/templates/db/migrate/api_ids_must_be_unique.rb
@@ -1,4 +1,4 @@
-class ApiIdsMustBeUnique < ActiveRecord::Migration
+class ApiIdsMustBeUnique < ActiveRecord::Migration[4.2]
   API_ID_TABLES = %w(surveys questions question_groups answers responses response_sets)
 
   class << self

--- a/lib/generators/surveyor/templates/db/migrate/create_answers.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_answers.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateAnswers < ActiveRecord::Migration
+class CreateAnswers < ActiveRecord::Migration[4.2]
   def self.up
     create_table :answers do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_dependencies.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_dependencies.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateDependencies < ActiveRecord::Migration
+class CreateDependencies < ActiveRecord::Migration[4.2]
   def self.up
     create_table :dependencies do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_dependency_conditions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_dependency_conditions.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateDependencyConditions < ActiveRecord::Migration
+class CreateDependencyConditions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :dependency_conditions do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_question_groups.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_question_groups.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateQuestionGroups < ActiveRecord::Migration
+class CreateQuestionGroups < ActiveRecord::Migration[4.2]
   def self.up
     create_table :question_groups do |t|
       # Content

--- a/lib/generators/surveyor/templates/db/migrate/create_questions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_questions.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateQuestions < ActiveRecord::Migration
+class CreateQuestions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :questions do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_response_sets.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_response_sets.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateResponseSets < ActiveRecord::Migration
+class CreateResponseSets < ActiveRecord::Migration[4.2]
   def self.up
     create_table :response_sets do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_responses.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_responses.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateResponses < ActiveRecord::Migration
+class CreateResponses < ActiveRecord::Migration[4.2]
   def self.up
     create_table :responses do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_skip_logic_conditions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_skip_logic_conditions.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateSkipLogicConditions < ActiveRecord::Migration
+class CreateSkipLogicConditions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :skip_logic_conditions do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_skip_logics.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_skip_logics.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateSkipLogics < ActiveRecord::Migration
+class CreateSkipLogics < ActiveRecord::Migration[4.2]
   def self.up
     create_table :skip_logics do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_survey_sections.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_survey_sections.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateSurveySections < ActiveRecord::Migration
+class CreateSurveySections < ActiveRecord::Migration[4.2]
   def self.up
     create_table :survey_sections do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_survey_translations.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_survey_translations.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateSurveyTranslations < ActiveRecord::Migration
+class CreateSurveyTranslations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :survey_translations do |t|
       # Content

--- a/lib/generators/surveyor/templates/db/migrate/create_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateSurveys < ActiveRecord::Migration
+class CreateSurveys < ActiveRecord::Migration[4.2]
   def self.up
     create_table :surveys do |t|
       # Content

--- a/lib/generators/surveyor/templates/db/migrate/create_validation_conditions.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_validation_conditions.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateValidationConditions < ActiveRecord::Migration
+class CreateValidationConditions < ActiveRecord::Migration[4.2]
   def self.up
     create_table :validation_conditions do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/create_validations.rb
+++ b/lib/generators/surveyor/templates/db/migrate/create_validations.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class CreateValidations < ActiveRecord::Migration
+class CreateValidations < ActiveRecord::Migration[4.2]
   def self.up
     create_table :validations do |t|
       # Context

--- a/lib/generators/surveyor/templates/db/migrate/drop_unique_index_on_access_code_in_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/drop_unique_index_on_access_code_in_surveys.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class DropUniqueIndexOnAccessCodeInSurveys < ActiveRecord::Migration
+class DropUniqueIndexOnAccessCodeInSurveys < ActiveRecord::Migration[4.2]
   def self.up
     remove_index( :surveys, :name => 'surveys_ac_idx' )
   end

--- a/lib/generators/surveyor/templates/db/migrate/increment_survey_versions_by_one.rb
+++ b/lib/generators/surveyor/templates/db/migrate/increment_survey_versions_by_one.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
-class IncrementSurveyVersionsByOne < ActiveRecord::Migration
+class IncrementSurveyVersionsByOne < ActiveRecord::Migration[5.0]
   def self.up
     remove_index(:surveys, name: 'surveys_access_code_version_idx')
 

--- a/lib/generators/surveyor/templates/db/migrate/update_blank_api_ids_on_question_group.rb
+++ b/lib/generators/surveyor/templates/db/migrate/update_blank_api_ids_on_question_group.rb
@@ -6,7 +6,7 @@ class Answer < ActiveRecord::Base; end
 class Response < ActiveRecord::Base; end
 class ResponseSet < ActiveRecord::Base; end
 
-class UpdateBlankApiIdsOnQuestionGroup < ActiveRecord::Migration
+class UpdateBlankApiIdsOnQuestionGroup < ActiveRecord::Migration[4.2]
   def self.up
     check = [Survey, Question, QuestionGroup, Answer, Response, ResponseSet]
     check.each do |clazz|

--- a/lib/generators/surveyor/templates/db/migrate/update_blank_versions_on_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/update_blank_versions_on_surveys.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 class Survey < ActiveRecord::Base; end
-class UpdateBlankVersionsOnSurveys < ActiveRecord::Migration
+class UpdateBlankVersionsOnSurveys < ActiveRecord::Migration[4.2]
   def self.up
     Survey.where('survey_version IS ?', nil).each do |s|
       s.survey_version = 0

--- a/lib/surveyor/models/answer_methods.rb
+++ b/lib/surveyor/models/answer_methods.rb
@@ -10,14 +10,14 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :question
+        belongs_to :question, required: false
         has_many :responses
-        has_many :validations, :dependent => :destroy
+        has_many :validations, dependent: :destroy
         attr_accessible *PermittedParams.new.answer_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations
         validates_presence_of :text
-        validates_inclusion_of :qualify_logic, :in => ["must", "may", "reject"]
+        validates_inclusion_of :qualify_logic, in: ["must", "may", "reject"]
 
         self.param_key = :a
       end

--- a/lib/surveyor/models/dependency_condition_methods.rb
+++ b/lib/surveyor/models/dependency_condition_methods.rb
@@ -8,16 +8,16 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :answer
-        belongs_to :dependency
-        belongs_to :dependent_question, :foreign_key => :question_id, :class_name => :question
-        belongs_to :question
+        belongs_to :answer, required: false
+        belongs_to :dependency, required: false
+        belongs_to :dependent_question, foreign_key: :question_id, class_name: :question, required: false
+        belongs_to :question, required: false
         attr_accessible *PermittedParams.new.dependency_condition_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations
         validates_presence_of :operator, :rule_key
         validate :validates_operator
-        validates_uniqueness_of :rule_key, :scope => :dependency_id
+        validates_uniqueness_of :rule_key, scope: :dependency_id
       end
 
       module ClassMethods

--- a/lib/surveyor/models/dependency_methods.rb
+++ b/lib/surveyor/models/dependency_methods.rb
@@ -7,9 +7,9 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :question
-        belongs_to :question_group
-        has_many :dependency_conditions, :dependent => :destroy
+        belongs_to :question, required: false
+        belongs_to :question_group, required: false
+        has_many :dependency_conditions, dependent: :destroy
         attr_accessible *PermittedParams.new.dependency_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/question_methods.rb
+++ b/lib/surveyor/models/question_methods.rb
@@ -11,11 +11,11 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :survey_section
-        belongs_to :question_group, :dependent => :destroy
-        has_many :answers, -> { order( 'display_order, id ASC' ) }, :dependent => :destroy, :autosave => true # it might not always have answers
+        belongs_to :survey_section, required: false
+        belongs_to :question_group, dependent: :destroy, required: false
+        has_many :answers, -> { order( 'display_order, id ASC' ) }, dependent: :destroy, autosave: true # it might not always have answers
         has_one :dependency, :dependent => :destroy
-        belongs_to :correct_answer, :class_name => "Answer", :dependent => :destroy
+        belongs_to :correct_answer, class_name: "Answer", dependent: :destroy, required: false
         attr_accessible *PermittedParams.new.question_attributes if defined? ActiveModel::MassAssignmentSecurity
         attr_accessor :response_group
         # Validations

--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -8,9 +8,9 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :response_set
-        belongs_to :question
-        belongs_to :answer
+        belongs_to :response_set, required: false
+        belongs_to :question, required: false
+        belongs_to :answer, required: false
         attr_accessible *PermittedParams.new.response_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -8,10 +8,10 @@ module Surveyor
       included do
         # Associations
         belongs_to :survey
-        belongs_to :user
-        belongs_to :current_section, :foreign_key => :current_section_id, :class_name => :survey_section
-        has_many :responses, :dependent => :destroy
-        accepts_nested_attributes_for :responses, :allow_destroy => true
+        belongs_to :user, required: false
+        belongs_to :current_section, foreign_key: :current_section_id, class_name: :survey_section, required: false
+        has_many :responses, dependent: :destroy
+        accepts_nested_attributes_for :responses, allow_destroy: true
         attr_accessible *PermittedParams.new.response_set_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/skip_logic_condition_methods.rb
+++ b/lib/surveyor/models/skip_logic_condition_methods.rb
@@ -8,18 +8,16 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :answer
-        belongs_to :skip_logic, :inverse_of => :skip_logic_conditions
-        belongs_to :dependent_question, :foreign_key => :question_id, :class_name => :question
-        belongs_to :question
+        belongs_to :answer, required: false
+        belongs_to :skip_logic, inverse_of: :skip_logic_conditions, required: true
+        belongs_to :dependent_question, foreign_key: :question_id, class_name: :question, required: false
+        belongs_to :question, required: true
         attr_accessible *PermittedParams.new.skip_logic_condition_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations
-        validates_presence_of :skip_logic
-        validates_presence_of :question
         validates_presence_of :operator, :rule_key
         validate :validates_operator
-        validates_uniqueness_of :rule_key, :scope => :skip_logic_id
+        validates_uniqueness_of :rule_key, scope: :skip_logic_id
       end
 
       module ClassMethods

--- a/lib/surveyor/models/skip_logic_methods.rb
+++ b/lib/surveyor/models/skip_logic_methods.rb
@@ -9,14 +9,14 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :survey_section, inverse_of: :skip_logics
-        belongs_to :target_survey_section, :foreign_key => :target_survey_section_id, :class_name => "SurveySection"
+        belongs_to :survey_section, inverse_of: :skip_logics, required: false
+        belongs_to :target_survey_section, foreign_key: :target_survey_section_id, class_name: "SurveySection", required: false
         has_many :skip_logic_conditions, inverse_of: :skip_logic, dependent: :destroy
         attr_accessible *PermittedParams.new.skip_logic_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations
         validates_presence_of :rule
-        validates_format_of :rule, :with => /\A(?:and|or|\)|\(|[A-Z]|\s)+\Z/ #TODO properly formed parenthesis etc.
+        validates_format_of :rule, with: /\A(?:and|or|\)|\(|[A-Z]|\s)+\Z/ #TODO properly formed parenthesis etc.
         validates_presence_of :survey_section
       end
 

--- a/lib/surveyor/models/survey_section_methods.rb
+++ b/lib/surveyor/models/survey_section_methods.rb
@@ -7,9 +7,9 @@ module Surveyor
 
       included do
         # Associations
-        has_many :questions, -> { order( 'display_order, id ASC' ) }, :dependent => :destroy, :autosave => true
-        has_many :skip_logics, -> { order( 'execute_order, id ASC' ) }, :dependent => :destroy, :autosave => true, :inverse_of => :survey_section
-        belongs_to :survey
+        has_many :questions, -> { order( 'display_order, id ASC' ) }, dependent: :destroy, autosave: true
+        has_many :skip_logics, -> { order( 'execute_order, id ASC' ) }, dependent: :destroy, autosave: true, inverse_of: :survey_section
+        belongs_to :survey, required: false
         attr_accessible *PermittedParams.new.survey_section_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/survey_translation_methods.rb
+++ b/lib/surveyor/models/survey_translation_methods.rb
@@ -7,7 +7,7 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :survey
+        belongs_to :survey, required: false
         attr_accessible *PermittedParams.new.survey_translation_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/lib/surveyor/models/validation_condition_methods.rb
+++ b/lib/surveyor/models/validation_condition_methods.rb
@@ -8,13 +8,13 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :validation
+        belongs_to :validation, required: false
         attr_accessible *PermittedParams.new.validation_condition_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations
         validates_presence_of :operator, :rule_key
-        validates_inclusion_of :operator, :in => Surveyor::Common::OPERATORS
-        validates_uniqueness_of :rule_key, :scope => :validation_id
+        validates_inclusion_of :operator, in: Surveyor::Common::OPERATORS
+        validates_uniqueness_of :rule_key, scope: :validation_id
       end
 
       # Instance Methods

--- a/lib/surveyor/models/validation_methods.rb
+++ b/lib/surveyor/models/validation_methods.rb
@@ -7,8 +7,8 @@ module Surveyor
 
       included do
         # Associations
-        belongs_to :answer
-        has_many :validation_conditions, :dependent => :destroy
+        belongs_to :answer, required: false
+        has_many :validation_conditions, dependent: :destroy
         attr_accessible *PermittedParams.new.validation_attributes if defined? ActiveModel::MassAssignmentSecurity
 
         # Validations

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -116,11 +116,6 @@ describe Answer do
   end
 
   context "for views" do
-    it "#text_for with #display_type == image" do
-      answer.text = "rails.png"
-      answer.display_type = :image
-      answer.text_for.should =~ /<img src="\/(images|assets)\/rails\.png" alt="Rails" \/>/
-    end
     it "#text_for with #display_type == hidden_label" do
       answer.text = "Red"
       answer.text_for.should == "Red"


### PR DESCRIPTION
Adds version numbers to the migration files in line with when they were created.

Adds required: false to belongs_to associations which are not required and
updates those which are required to be explicit so we do not rely on the config
being set up properly in an app.

Removes a spec which doesn't run any more due to removed assets as the FE
concerns were removed.

Closes user-interviews/rails-server#4292