### PR TITLE
Feature/rs 7111 inverse of for question answer association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 History for Surveyor
 ====================
 
+3.3.1
+-----
+Added `inverse_of: :question` to Answer association in question_methods to prevent n+1 loading from as_json call after serialization.
+
 3.3.0
 -----
 Require Ruby 2.6.7, drop Rails < 5.2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    surveyor (3.3.0)
+    surveyor (3.3.1)
       mustache (~> 1.1.1)
       rails (>= 5.2.6)
       uuidtools (~> 2.2.0)

--- a/lib/surveyor/models/question_methods.rb
+++ b/lib/surveyor/models/question_methods.rb
@@ -17,6 +17,7 @@ module Surveyor
         belongs_to :question_group, dependent: :destroy, optional: true
         has_many :answers,
           -> { order('display_order, id ASC') },
+          inverse_of: :question,
           dependent: :destroy,
           autosave: true # it might not always have answers
 

--- a/lib/surveyor/version.rb
+++ b/lib/surveyor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Surveyor
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end


### PR DESCRIPTION
1. Added `inverse_of: :question` to the `has_many :answers` declaration in `question_methods.rb` to prevent n+1 when calling `as_json` after serialization despite eager loading.
2. Bumped version to `3.3.1`